### PR TITLE
Remove table of tables/figures

### DIFF
--- a/v1-1/FIXDisclaimerTechStd.md
+++ b/v1-1/FIXDisclaimerTechStd.md
@@ -1,11 +1,3 @@
-::: {custom-style="TOC Heading"}
-Table of Tables
-:::
-
-::: {custom-style="TOC Heading"}
-Table of Figures
-:::
-
 ::: {custom-style=Disclaimer}
 DISCLAIMER
 :::


### PR DESCRIPTION
Pandoc v3.5 can generate the list of tables and figures automatically. Previously, only the header were present in markdown and the lists had to be generated manually in the docx file before exporting to PDF.